### PR TITLE
Protect replacement of "/../.." or "/./.." for "/" during import.

### DIFF
--- a/min/lib/Minify/ImportProcessor.php
+++ b/min/lib/Minify/ImportProcessor.php
@@ -148,7 +148,7 @@ class Minify_ImportProcessor {
                 $url = str_replace('/./', '/', $url);
                 // inspired by patch from Oleg Cherniy
                 do {
-                    $url = preg_replace('@/[^/]+/\\.\\./@', '/', $url, 1, $changed);
+                    $url = preg_replace('@/(?!\\.\\.?)[^/]+/\\.\\.@', '/', $url, 1, $changed);
                 } while ($changed);
             }
         }


### PR DESCRIPTION
The regex in cc62534837915d0f5c6930efa3f7013d8c3a092f is broken as it will replace `/../..` or `/./..` with `/` which is clearly wrong.

I've added a negative lookahead to prevent these special cases.
