### PR TITLE
YUICompressor should alert when java executable is not found or went wrong (issue #17)

### DIFF
--- a/min/lib/Minify/YUICompressor.php
+++ b/min/lib/Minify/YUICompressor.php
@@ -92,7 +92,7 @@ class Minify_YUICompressor {
         file_put_contents($tmpFile, $content);
         exec(self::_getCmd($options, $type, $tmpFile), $output, $result_code);
         unlink($tmpFile);
-        if($result_code != 0){
+        if ($result_code != 0) {
             throw new Exception('Minify_YUICompressor : YUI compressor execution failed.');
         }
         return implode("\n", $output);


### PR DESCRIPTION
Added two exceptions:
- when java cannot be executed
- When execution result_code of yui compressor is not 0 (i.e execution success).
