### PR TITLE
Minify_Cache_File::store() improvements

### DIFF
--- a/min/lib/Minify/Cache/File.php
+++ b/min/lib/Minify/Cache/File.php
@@ -30,12 +30,8 @@ class Minify_Cache_File {
             ? LOCK_EX
             : null;
         $file = $this->_path . '/' . $id;
-        if (is_file($file)) {
-            @unlink($file);
-        }
         if (! @file_put_contents($file, $data, $flag)) {
             $this->_log("Minify_Cache_File: Write failed to '$file'");
-            return false;
         }
         // write control
         if ($data !== $this->fetch($id)) {


### PR DESCRIPTION
Don't need to unlink file because file_put_contents will handle that. Also, don't return false after file_put_contents fails in case it creates a zero size file (use the existing "does the data match" check to ensure that the zero size file gets unlinked).
