### PR TITLE
fix invalid executable requirement on .jar file

### DIFF
--- a/min/lib/Minify/YUICompressor.php
+++ b/min/lib/Minify/YUICompressor.php
@@ -134,8 +134,8 @@ class Minify_YUICompressor {
         if (! is_file(self::$jarFile)) {
             throw new Exception('Minify_YUICompressor : $jarFile('.self::$jarFile.') is not a valid file.');
         }
-        if (! is_executable(self::$jarFile)) {
-            throw new Exception('Minify_YUICompressor : $jarFile('.self::$jarFile.') is not executable.');
+        if (! is_readable(self::$jarFile)) {
+            throw new Exception('Minify_YUICompressor : $jarFile('.self::$jarFile.') is not readable.');
         }
         if (! is_dir(self::$tempDir)) {
             throw new Exception('Minify_YUICompressor : $tempDir('.self::$tempDir.') is not a valid direcotry.');


### PR DESCRIPTION
jarFile does not need to be executable, just readable

if executable check is wanted to be made, it should be done on $java executable

but it's complicated because $java is searched from $PATH, meaning you should do $PATH scanning for each component. so let it just check for jar file readability
