### PR TITLE
Add google closure compiler cli version

### DIFF
--- a/min/lib/Minify/ClosureCompiler.php
+++ b/min/lib/Minify/ClosureCompiler.php
@@ -86,7 +86,7 @@ class Minify_ClosureCompiler {
         $o = array_merge(
             array(
                 'charset' => 'utf-8',
-                'compilation_level' => '',
+                'compilation_level' => 'SIMPLE_OPTIMIZATIONS',
             ),
             $userOptions
         );


### PR DESCRIPTION
I used YUICompressor.php as base for creating CLI version of google closure compiler, therefore it resides in same dir as well.

probably this should be merged with JS/ClosureCompiler.php somehow to support online and offline operation

this includes basic support, --charset and --compilation_level can be configured

to use this compiler, use something like:

```
$min_serveOptions['minifiers'][Minify::TYPE_JS] = array('Minify_ClosureCompiler', 'minify');
$min_serveOptions['minifierOptions'][Minify::TYPE_JS]['charset'] = 'utf-8';
$min_serveOptions['minifierOptions'][Minify::TYPE_JS]['compilation_level'] = 'SIMPLE_OPTIMIZATIONS';
require_once 'Minify/ClosureCompiler.php';
Minify_ClosureCompiler::$tempDir = '/tmp';
Minify_ClosureCompiler::$jarFile = '/usr/share/java/closure-compiler.jar';
```
