### PR TITLE
Path/require problem in cli script min_extras/cli/minify.php

### DIFF
--- a/min_extras/cli/minify.php
+++ b/min_extras/cli/minify.php
@@ -3,7 +3,7 @@
 
 $pathToLib = dirname(dirname(__DIR__)) . '/min/lib';
 
-require "$min_libPath/Minify/Loader.php";
+require "$pathToLib/Minify/Loader.php";
 Minify_Loader::register();
 
 $cli = new MrClay\Cli;


### PR DESCRIPTION
I think the path variable got renamed inconsistently?
