### PR TITLE
Make cli script more portable

### DIFF
--- a/min_extras/cli/minify.php
+++ b/min_extras/cli/minify.php
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 $pathToLib = dirname(dirname(__DIR__)) . '/min/lib';


### PR DESCRIPTION
Changing hash-bang interpreter to `#!/usr/bin/env php`, for better portability with non-linux OSs such as BSD.
