### PR TITLE
use "Connection: close" of file_get_contents

### DIFF
--- a/min/lib/Minify/JS/ClosureCompiler.php
+++ b/min/lib/Minify/JS/ClosureCompiler.php
@@ -69,7 +69,7 @@ class Minify_JS_ClosureCompiler {
         }
         return $response;
     }
-    
+
     protected $_fallbackFunc = null;
 
     protected function _getResponse($postBody)
@@ -79,7 +79,7 @@ class Minify_JS_ClosureCompiler {
             $contents = file_get_contents(self::URL, false, stream_context_create(array(
                 'http' => array(
                     'method' => 'POST',
-                    'header' => 'Content-type: application/x-www-form-urlencoded',
+                    'header' => "Content-type: application/x-www-form-urlencoded\r\nConnection: close\r\n",
                     'content' => $postBody,
                     'max_redirects' => 0,
                     'timeout' => 15,


### PR DESCRIPTION
otherwise php will do keepalive request, and wait timeout seconds before
can return actual response. similar problem does not happen with curl
backend
