### PR TITLE
Html5

### DIFF
--- a/min/lib/Minify/HTML.php
+++ b/min/lib/Minify/HTML.php
@@ -35,8 +35,8 @@ class Minify_HTML {
      * 'jsMinifier' : (optional) callback function to process content of SCRIPT
      * elements. Note: the type attribute is ignored.
      *
-     * 'xhtml' : (optional boolean) should content be treated as XHTML1.0? If
-     * unset, minify will sniff for an XHTML doctype.
+     * 'doctype' : (optional) what the doctype is of the content. If
+     * unset, minify will sniff for a doctype.
      *
      * @return string
      */
@@ -81,9 +81,6 @@ class Minify_HTML {
         }
         if (isset($options['jsCleanComments'])) {
             $this->_jsCleanComments = (bool)$options['jsCleanComments'];
-        }
-        if (isset($options['html5'])) {
-            $this->_isHtml5 = (bool)$options['html5'];
         }
     }
 


### PR DESCRIPTION
change of _isXhtml to _doctype to handle more than one doctype, keeping the default the same.
Added doctype handling of html5 with new html5 elements that are defaulted to block / hidden layout, as well as sniffing for html5 doctype.
