### PR TITLE
add parameters support to getContentFunc Minify_Source callbacks

### DIFF
--- a/min/lib/Minify/Source.php
+++ b/min/lib/Minify/Source.php
@@ -81,6 +81,9 @@ class Minify_Source {
                 $this->_content = $spec['content'];
             } else {
                 $this->_getContentFunc = $spec['getContentFunc'];
+                $this->_getContentFuncParams = isset($spec['getContentFuncParams'])
+                    ? $spec['getContentFuncParams']
+                    : array();
             }
             $this->lastModified = isset($spec['lastModified'])
                 ? $spec['lastModified']
@@ -108,7 +111,7 @@ class Minify_Source {
             ? file_get_contents($this->filepath)
             : ((null !== $this->_content)
                 ? $this->_content
-                : call_user_func($this->_getContentFunc, $this->_id)
+                : call_user_func_array($this->_getContentFunc, array_merge(array($this->_id), $this->_getContentFuncParams))
             );
         // remove UTF-8 BOM if present
         return (pack("CCC",0xef,0xbb,0xbf) === substr($content, 0, 3))
@@ -182,6 +185,7 @@ class Minify_Source {
     
     protected $_content = null;
     protected $_getContentFunc = null;
+    protected $_getContentFuncParams = array();
     protected $_id = null;
 }
 


### PR DESCRIPTION
This is useful for getContent in Minify_Source if you need to pass extra data when building response content. Without this, I would have to duplicate logic in `foo`, so this would help to reuse existing variables, objects... 

``` php
    public static function foo($configpath, $app, $opts = array()) {
        /* @var $config */
        require $configpath;
        $cb = foobar::create($config, $app);
        $lastModified = Minify_HTML_Helper::getLastModified($cb->getDependencies());

        $config['load_module'] = !empty($_GET['cb']) ? (string)$_GET['cb'] : $config['instance'];

        $opts = array(
            'id' => $configpath . ':' . $app . ':'. $config['load_module'],
            'lastModified' => $lastModified,
            'getContentFunc' => array(__CLASS__, 'foo_callback'),
            'getContentFuncParams' => array(
                $cb,
                $config,
            ),
        );

        $file = new Minify_Source($opts);
        return $file;
    }

    public static function foo_callback($id, $cb, $config) {
        return $cb->get($config);
    }
```
