### PR TITLE
Allow option for overriding the maximum byte size POST limit

### DIFF
--- a/min_unit_tests/test_Minify_JS_ClosureCompiler.php
+++ b/min_unit_tests/test_Minify_JS_ClosureCompiler.php
@@ -42,6 +42,59 @@ function test_Minify_JS_ClosureCompiler()
     if (__FILE__ === realpath($_SERVER['SCRIPT_FILENAME'])) {
         echo "\n---Message: " . var_export($exc->getMessage(), 1) . "\n\n\n";
     }
+
+    // Test maximum byte size check (default)
+    $fn = "(function() {})();";
+    $src = str_repeat($fn, ceil(Minify_JS_ClosureCompiler::OPTION_MAX_BYTES_DEFAULT / strlen($fn)));
+    $exc = null;
+    try {
+        $minOutput = Minify_JS_ClosureCompiler::minify($src);
+    } catch (Exception $e) {
+        $exc = $e;
+    }
+    $passed = assertTrue(
+        $exc instanceof Minify_JS_ClosureCompiler_Exception
+        , 'Minify_JS_ClosureCompiler : Throws Minify_JS_ClosureCompiler_Exception');
+    assertTrue(
+        $exc->getMessage() === 'POST content larger than ' . Minify_JS_ClosureCompiler::OPTION_MAX_BYTES_DEFAULT . ' bytes'
+        , 'Minify_JS_ClosureCompiler : Message must tell how big maximum byte size is');
+    if (__FILE__ === realpath($_SERVER['SCRIPT_FILENAME'])) {
+        echo "\n---Message: " . var_export($exc->getMessage(), 1) . "\n\n\n";
+    }
+
+    // Test maximum byte size check (no limit)
+    $src = "(function(){})();";
+    try {
+        $minOutput = Minify_JS_ClosureCompiler::minify($src, array(
+            Minify_JS_ClosureCompiler::OPTION_MAX_BYTES => Minify_JS_ClosureCompiler::OPTION_MAX_BYTES_NO_LIMIT
+        ));
+    } catch (Exception $e) {
+        $exc = $e;
+    }
+    $passed = assertTrue(
+        $src === $minOutput
+        , 'Minify_JS_ClosureCompiler : With no limit set,  it should compile properly');
+
+    // Test maximum byte size check (custom)
+    $src = "(function() {})();";
+    $allowedBytes = 5;
+    $exc = null;
+    try {
+        $minOutput = Minify_JS_ClosureCompiler::minify($src, array(
+            Minify_JS_ClosureCompiler::OPTION_MAX_BYTES => $allowedBytes
+        ));
+    } catch (Exception $e) {
+        $exc = $e;
+    }
+    $passed = assertTrue(
+        $exc instanceof Minify_JS_ClosureCompiler_Exception
+        , 'Minify_JS_ClosureCompiler : Throws Minify_JS_ClosureCompiler_Exception');
+    assertTrue(
+        $exc->getMessage() === 'POST content larger than ' . $allowedBytes . ' bytes'
+        , 'Minify_JS_ClosureCompiler : Message must tell how big maximum byte size is');
+    if (__FILE__ === realpath($_SERVER['SCRIPT_FILENAME'])) {
+        echo "\n---Message: " . var_export($exc->getMessage(), 1) . "\n\n\n";
+    }
 }
 
 test_Minify_JS_ClosureCompiler();


### PR DESCRIPTION
We are using our own compiler service, which has different limits to the default appspot one, so we need the maximum file size to be configurable.
