### PR TITLE
Allow additional HTTP options to be passed to the Closure compiler service

### DIFF
--- a/min/lib/Minify/JS/ClosureCompiler.php
+++ b/min/lib/Minify/JS/ClosureCompiler.php
@@ -20,6 +20,26 @@ class Minify_JS_ClosureCompiler {
     protected $url = 'http://closure-compiler.appspot.com/compile';
 
     /**
+    * @var $additionalOptions array additional options to pass to the compiler service
+    */
+    protected $additionalOptions = array();
+
+    /**
+    * @var $DEFAULT_OPTIONS array the default options to pass to the compiler service
+    */
+    private static $DEFAULT_OPTIONS = array(
+                            'output_format' => 'text',
+                            'compilation_level' => 'SIMPLE_OPTIMIZATIONS');
+
+    /**
+    * @var string the option for additional params.
+    * Read more about additional params here: https://developers.google.com/closure/compiler/docs/api-ref
+    * This also allows you to override the output_format or the compilation_level.
+    * The parameters js_code and output_info can not be set in this way
+    */
+    const OPTION_ADDITIONAL_HTTP_PARAMS = 'additionalParams';
+
+    /**
      * Minify Javascript code via HTTP request to the Closure Compiler API
      *
      * @param string $js input code
@@ -47,6 +67,10 @@ class Minify_JS_ClosureCompiler {
 
         if (isset($options['compilerUrl'])) {
             $this->url = $options['compilerUrl'];
+        }
+
+        if (isset($options[self::OPTION_ADDITIONAL_HTTP_PARAMS]) && is_array($options[self::OPTION_ADDITIONAL_HTTP_PARAMS])) {
+            $this->additionalOptions = $options[self::OPTION_ADDITIONAL_HTTP_PARAMS];
         }
     }
 
@@ -118,12 +142,18 @@ class Minify_JS_ClosureCompiler {
 
     protected function _buildPostBody($js, $returnErrors = false)
     {
-        return http_build_query(array(
-            'js_code' => $js,
-            'output_info' => ($returnErrors ? 'errors' : 'compiled_code'),
-            'output_format' => 'text',
-            'compilation_level' => 'SIMPLE_OPTIMIZATIONS'
-        ), null, '&');
+        return http_build_query(
+            array_merge(
+                self::$DEFAULT_OPTIONS,
+                $this->additionalOptions,
+                array(
+                    'js_code' => $js,
+                    'output_info' => ($returnErrors ? 'errors' : 'compiled_code')
+                )
+            ),
+            null,
+            '&'
+        );
     }
 
     /**

--- a/min_unit_tests/test_Minify_JS_ClosureCompiler.php
+++ b/min_unit_tests/test_Minify_JS_ClosureCompiler.php
@@ -42,6 +42,31 @@ function test_Minify_JS_ClosureCompiler()
     if (__FILE__ === realpath($_SERVER['SCRIPT_FILENAME'])) {
         echo "\n---Message: " . var_export($exc->getMessage(), 1) . "\n\n\n";
     }
+
+    // Test additional options passed to HTTP request
+    $ecmascript5 = "[1,].length;";
+    $exc = null;
+    try {
+        $minOutput = Minify_JS_ClosureCompiler::minify($ecmascript5);
+    } catch (Exception $e) {
+        $exc = $e;
+    }
+    $passed = assertTrue(
+        $exc instanceof Minify_JS_ClosureCompiler_Exception
+        , 'Minify_JS_ClosureCompiler : Throws Minify_JS_ClosureCompiler_Exception');
+    if (__FILE__ === realpath($_SERVER['SCRIPT_FILENAME'])) {
+        echo "\n---Message: " . var_export($exc->getMessage(), 1) . "\n\n\n";
+    }
+
+    $minExpected = '1;';
+    $minOutput = Minify_JS_ClosureCompiler::minify($ecmascript5, array(
+        Minify_JS_ClosureCompiler::OPTION_ADDITIONAL_HTTP_PARAMS => array(
+            'language' => 'ECMASCRIPT5'
+            )
+    ));
+    $passed = assertTrue(
+        $minOutput === $minExpected
+        , 'Minify_JS_ClosureCompiler : Language option should make it compile');
 }
 
 test_Minify_JS_ClosureCompiler();


### PR DESCRIPTION
Our project needs to be able to set additional compiler options for the closure compiler service. This pull request adds this feature.
