### PR TITLE
Exclude build/development tools from releases using .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/.editorconfig  export-ignore
+/.gitignore     export-ignore
+/.gitattributes export-ignore
+/min_extras     export-ignore
+/min_unit_tests export-ignore


### PR DESCRIPTION
It is conventional to exclude build/development scripts from published packages.

See https://github.com/laravel/framework/blob/master/.gitattributes for one of many examples.

This particularly applies to the `min_extras` folder, which contains a warning to remove it on production sites.  I guess few people will find this warning...
