### PR TITLE
Fix greediness of CSS whitespace in selector regex

### DIFF
--- a/min/lib/Minify/CSS/Compressor.php
+++ b/min/lib/Minify/CSS/Compressor.php
@@ -129,15 +129,15 @@ class Minify_CSS_Compressor {
         
         // remove spaces between font families
         $css = preg_replace_callback('/
-				(					# 1 = CSS declaration
-					font-family:	# select font-family
-					|
-					font:			# select font
-					(?:\w+\s*)+		# if font, also select its properties (style, size..)
-				)
-				([^;}]+)			# select all fonts
-				([;}])				# end declaration
-			/x'
+                (                    # 1 = CSS declaration
+                    font-family:     # select font-family
+                    |
+                    font:            # select font
+                    (?:\w+\s*)+      # if font, also select its properties (style, size..)
+                )
+                ([^;}]+)             # select all fonts
+                ([;}])               # end declaration
+            /x'
             ,array($this, '_fontFamilyCB'), $css);
         
         $css = preg_replace('/@import\\s+url/', '@import url', $css);

--- a/min/lib/Minify/CSS/Compressor.php
+++ b/min/lib/Minify/CSS/Compressor.php
@@ -111,15 +111,15 @@ class Minify_CSS_Compressor {
         
         // remove ws in selectors
         $css = preg_replace_callback('/
-                (?:              # non-capture
+                (?:                  # non-capture
                     \\s*
                     [^{};%~>+,\\s]+  # selector part
                     \\s*
-                    [,>+~]       # combinators
+                    [,>+~]           # combinators
                 )+
                 \\s*
                 [^{};%~>+,\\s]+      # selector part
-                {                # open declaration block
+                {                    # open declaration block
             /x'
             ,array($this, '_selectorsCB'), $css);
         
@@ -128,7 +128,7 @@ class Minify_CSS_Compressor {
             , '$1#$2$3$4$5', $css);
         
         // remove spaces between font families
-        $css = preg_replace_callback('/font-family:([^;}]+)([;}])/'
+        $css = preg_replace_callback('/(font-family:|font:(?:\w+\s*)+)([^;}]+)([;}])/'
             ,array($this, '_fontFamilyCB'), $css);
         
         $css = preg_replace('/@import\\s+url/', '@import url', $css);
@@ -235,8 +235,8 @@ class Minify_CSS_Compressor {
     protected function _fontFamilyCB($m)
     {
         // Issue 210: must not eliminate WS between words in unquoted families
-        $pieces = preg_split('/(\'[^\']+\'|"[^"]+")/', $m[1], null, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
-        $out = 'font-family:';
+        $pieces = preg_split('/(\'[^\']+\'|"[^"]+")/', $m[2], null, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+        $out = $m[1];
         while (null !== ($piece = array_shift($pieces))) {
             if ($piece[0] !== '"' && $piece[0] !== "'") {
                 $piece = preg_replace('/\\s+/', ' ', $piece);
@@ -244,6 +244,6 @@ class Minify_CSS_Compressor {
             }
             $out .= $piece;
         }
-        return $out . $m[2];
+        return $out . $m[3];
     }
 }

--- a/min/lib/Minify/CSS/Compressor.php
+++ b/min/lib/Minify/CSS/Compressor.php
@@ -128,7 +128,16 @@ class Minify_CSS_Compressor {
             , '$1#$2$3$4$5', $css);
         
         // remove spaces between font families
-        $css = preg_replace_callback('/(font-family:|font:(?:\w+\s*)+)([^;}]+)([;}])/'
+        $css = preg_replace_callback('/
+				(					# 1 = CSS declaration
+					font-family:	# select font-family
+					|
+					font:			# select font
+					(?:\w+\s*)+		# if font, also select its properties (style, size..)
+				)
+				([^;}]+)			# select all fonts
+				([;}])				# end declaration
+			/x'
             ,array($this, '_fontFamilyCB'), $css);
         
         $css = preg_replace('/@import\\s+url/', '@import url', $css);

--- a/min/lib/Minify/CSS/Compressor.php
+++ b/min/lib/Minify/CSS/Compressor.php
@@ -113,12 +113,12 @@ class Minify_CSS_Compressor {
         $css = preg_replace_callback('/
                 (?:              # non-capture
                     \\s*
-                    [^~>+,\\s]+  # selector part
+                    [^{};%~>+,\\s]+  # selector part
                     \\s*
                     [,>+~]       # combinators
                 )+
                 \\s*
-                [^~>+,\\s]+      # selector part
+                [^{};%~>+,\\s]+      # selector part
                 {                # open declaration block
             /x'
             ,array($this, '_selectorsCB'), $css);

--- a/min_unit_tests/_test_files/css/calc.css
+++ b/min_unit_tests/_test_files/css/calc.css
@@ -1,0 +1,29 @@
+div.price {
+	color: #33691E;
+	margin: 0.5em 0;
+	font-size: 1.15em;
+	font-weight: bold;
+}
+
+div.overlay {
+	position: relative;
+	width: 100%;
+	height: 100%;
+	background: transparent;
+	top: 100%;
+	margin-top: calc(33% + 24px);
+	pointer-events: none;
+}
+
+.overlay.no-scroll {
+	pointer-events: auto;
+}
+
+a.button {
+	display: inline-block;
+	color: #000000;
+}
+
+a.button:hover {
+	color: #000000;
+}

--- a/min_unit_tests/_test_files/css/calc.min.css
+++ b/min_unit_tests/_test_files/css/calc.min.css
@@ -1,0 +1,1 @@
+div.price{color:#33691E;margin:0.5em 0;font-size:1.15em;font-weight:bold}div.overlay{position:relative;width:100%;height:100%;background:transparent;top:100%;margin-top:calc(33% + 24px);pointer-events:none}.overlay.no-scroll{pointer-events:auto}a.button{display:inline-block;color:#000}a.button:hover{color:#000}

--- a/min_unit_tests/_test_files/css/font.css
+++ b/min_unit_tests/_test_files/css/font.css
@@ -1,0 +1,14 @@
+/* Examples from https://developer.mozilla.org/en-US/docs/Web/CSS/font */
+body {
+	/* size | family */
+	font: 2em "Open Sans", sans-serif;
+
+	/* style | size | family */
+	font: italic 2em "Open Sans", sans-serif;
+
+	/* style | variant | weight | size/line-height | family */
+	font: italic small-caps bolder 16px/3 cursive;
+
+	/* The font used in system dialogs */
+	font: message-box;
+}

--- a/min_unit_tests/_test_files/css/font.min.css
+++ b/min_unit_tests/_test_files/css/font.min.css
@@ -1,0 +1,1 @@
+body{font:2em "Open Sans",sans-serif;font:italic 2em "Open Sans",sans-serif;font:italic small-caps bolder 16px/3 cursive;font:message-box}


### PR DESCRIPTION
*This new pull request now excludes the README-changing commit.*

The original issue: the minifier would minify the `calc()` CSS function, transforming a property value from something like `calc(33% + 24px)` to `calc(33%+24px)`, which is invalid in CSS, as the calc function requires the calculation operator to be surrounded by spaces.

The problem was that this property was being caught in the selector whitespace regex. This is fixed by adding additional constraints into the regex - more specifically, it does not allow the regex to select text that has opening/closing braces, a semicolon, or a percent sign, while leaving the combinators the same.

As this was fixed, the subsilver unit test failed, because the CSS file contained a `font` property which was not being parsed by the minifier. I then added support, in the font family regex, for the `font` property, with its additional properties. All unit tests now pass.

Additional unit tests for CSS have been added, for testing the minification of `font` properties as well as the `calc()` function. 