### PR TITLE
Allow specifying files via $min_symlinks paths

### DIFF
--- a/index.php
+++ b/index.php
@@ -52,6 +52,7 @@ $server = new Minify($cache);
 // TODO probably should do this elsewhere...
 $min_serveOptions['minifierOptions']['text/css']['docRoot'] = $env->getDocRoot();
 $min_serveOptions['minifierOptions']['text/css']['symlinks'] = $min_symlinks;
+$min_serveOptions['minApp']['symlinks'] = $min_symlinks;
 // auto-add targets to allowDirs
 foreach ($min_symlinks as $uri => $target) {
     $min_serveOptions['minApp']['allowDirs'][] = $target;

--- a/lib/Minify/CSS/UriRewriter.php
+++ b/lib/Minify/CSS/UriRewriter.php
@@ -48,8 +48,8 @@ class Minify_CSS_UriRewriter {
         );
         self::$_currentDir = self::_realpath($currentDir);
         self::$_symlinks = array();
-        
-        // normalize symlinks
+
+        // normalize symlinks in order to map to link
         foreach ($symlinks as $link => $target) {
             $link = ($link === '//')
                 ? self::$_docRoot


### PR DESCRIPTION
If you have an alias/symlink like "//~name" => "/full/path", then you can now serve with the more logical URL http://example.com/min/?f=~name/foo.css

Fixes #137