### PR TITLE
Changed array notation from php 5.4 [] syntax to Array() syntax. #481

### DIFF
--- a/lib/Minify.php
+++ b/lib/Minify.php
@@ -408,9 +408,9 @@ class Minify {
         $this->cache = new Minify_Cache_Null();
 
         $env = new Minify_Env();
-        $sourceFactory = new Minify_Source_Factory($env, [
+        $sourceFactory = new Minify_Source_Factory($env, array(
             'checkAllowDirs' => false,
-        ], $this->cache);
+        ), $this->cache);
         $controller = new Minify_Controller_Files($env, $sourceFactory);
 
         $options = array_merge($options, array(


### PR DESCRIPTION
Changed array notation from php 5.4 [] syntax to Array() syntax to maintain backward compatibility with 5.3

fixing #481