### PR TITLE
normalize paths before checking allowed dirs

### DIFF
--- a/index.php
+++ b/index.php
@@ -120,6 +120,11 @@ $sourceFactoryOptions = array();
 if (isset($min_serveOptions['minApp']['noMinPattern'])) {
     $sourceFactoryOptions['noMinPattern'] = $min_serveOptions['minApp']['noMinPattern'];
 }
+
+if (isset($min_serveOptions['minApp']['allowDirs'])) {
+   $sourceFactoryOptions['allowDirs'] = $min_serveOptions['minApp']['allowDirs'];
+}
+
 $sourceFactory = new Minify_Source_Factory($env, $sourceFactoryOptions, $cache);
 
 $controller = call_user_func($min_factories['controller'], $env, $sourceFactory);

--- a/lib/Minify/Source/Factory.php
+++ b/lib/Minify/Source/Factory.php
@@ -112,20 +112,15 @@ class Minify_Source_Factory {
 
 
     /**
-     * @param string  $path
+     * @param string $path
      * @return string
      */
     public function getNormalizedPath($path)
     {
-        // turn windows-style slashes into unix-style
-        $norm = str_replace("\\", "/", $path);
-
-        // lowercase drive letter
-        if (preg_match('/^\w:/', $norm)) {
-            $norm = lcfirst($norm);
-        }
-
-        return $norm;
+        // turn windows-style slashes into unix-style,
+        // remove trailing slash
+        // and lowercase drive letter
+        return lcfirst(rtrim(str_replace('\\', '/', $path), '/'));
     }
 
 

--- a/lib/Minify/Source/Factory.php
+++ b/lib/Minify/Source/Factory.php
@@ -153,11 +153,16 @@ class Minify_Source_Factory {
         }
 
         if ($this->options['checkAllowDirs']) {
+            $inAllowedDir = false;
             foreach ((array)$this->options['allowDirs'] as $allowDir) {
-                if (strpos($this->getNormalizedPath($spec['filepath']), $this->getNormalizedPath($allowDir)) !== 0) {
-                    throw new Minify_Source_FactoryException("File '{$spec['filepath']}' is outside \$allowDirs."
-                        . " If the path is resolved via an alias/symlink, look into the \$min_symlinks option.");
+                if (strpos($this->getNormalizedPath($spec['filepath']), $this->getNormalizedPath($allowDir)) === 0) {
+                    $inAllowedDir = true;
                 }
+            }
+
+            if (!$inAllowedDir) {
+                throw new Minify_Source_FactoryException("File '{$spec['filepath']}' is outside \$allowDirs."
+                    . " If the path is resolved via an alias/symlink, look into the \$min_symlinks option.");
             }
         }
 

--- a/lib/Minify/Source/Factory.php
+++ b/lib/Minify/Source/Factory.php
@@ -110,6 +110,25 @@ class Minify_Source_Factory {
         return $realpath;
     }
 
+
+    /**
+     * @param string  $path
+     * @return string
+     */
+    public function getNormalizedPath($path)
+    {
+        // turn windows-style slashes into unix-style
+        $norm = str_replace("\\", "/", $path);
+
+        // lowercase drive letter
+        if (preg_match('/^\w:/', $norm)) {
+            $norm = lcfirst($norm);
+        }
+
+        return $norm;
+    }
+
+
     /**
      * @param mixed $spec
      *
@@ -140,7 +159,7 @@ class Minify_Source_Factory {
 
         if ($this->options['checkAllowDirs']) {
             foreach ((array)$this->options['allowDirs'] as $allowDir) {
-                if (strpos($spec['filepath'], $allowDir) !== 0) {
+                if (strpos($this->getNormalizedPath($spec['filepath']), $this->getNormalizedPath($allowDir)) !== 0) {
                     throw new Minify_Source_FactoryException("File '{$spec['filepath']}' is outside \$allowDirs."
                         . " If the path is resolved via an alias/symlink, look into the \$min_symlinks option.");
                 }


### PR DESCRIPTION
Turns windows-style slashes into unix-style, and makes drive letters lowercase. Fixes false errors like "File ... is outside $allowDirs" at systems running under Windows.