### PR TITLE
Minify no longer tries to minify -min.js/.min.js files

### DIFF
--- a/docs/CustomSource.wiki.md
+++ b/docs/CustomSource.wiki.md
@@ -39,7 +39,7 @@ $src1 = new Minify_Source(array(
 ));
 $src2 = new Minify_Source(array(
     'filepath' => '//js/file2.js',
-    'minifier' => '', // don't compress
+    'minifier' => 'Minify::nullMinifier', // don't compress
 ));
 ```
 In the above, `JmyJsMinifier()` is only called when the contents of `$src1` is needed.

--- a/lib/Minify.php
+++ b/lib/Minify.php
@@ -168,7 +168,7 @@ class Minify {
      * $options['minifiers'][Minify::TYPE_CSS] = 'customCssMinifier';
      *
      * // don't minify Javascript at all
-     * $options['minifiers'][Minify::TYPE_JS] = '';
+     * $options['minifiers'][Minify::TYPE_JS] = 'Minify::nullMinifier';
      * </code>
      *
      * 'minifierOptions' : to send options to the minifier function, specify your options
@@ -293,7 +293,7 @@ class Minify {
             $this->options['minifiers'][self::TYPE_JS] = false;
             foreach ($this->sources as $key => $source) {
                 if ($this->options['contentType'] === self::TYPE_JS) {
-                    $source->setMinifier("");
+                    $source->setMinifier('Minify::nullMinifier');
                 } elseif ($this->options['contentType'] === self::TYPE_CSS) {
                     $source->setMinifier(array('Minify_CSSmin', 'minify'));
                     $sourceOpts = $source->getMinifierOptions();
@@ -456,6 +456,20 @@ class Minify {
             echo "<p>Please see <a href='$url'>$url</a>.</p>";
         }
         exit;
+    }
+
+    /**
+     * Default minifier for .min or -min JS files.
+     *
+     * @param string $content
+     * @return string
+     */
+    public static function nullMinifier($content) {
+        if (isset($content[0]) && $content[0] === "\xef") {
+            $content = substr($content, 3);
+        }
+        $content = str_replace("\r\n", "\n", $content);
+        return trim($content);
     }
 
     /**

--- a/lib/Minify/Controller/MinApp.php
+++ b/lib/Minify/Controller/MinApp.php
@@ -190,7 +190,7 @@ class Minify_Controller_MinApp extends Minify_Controller_Base {
                 ,'lastModified' => 0
                 // due to caching, filename is unreliable.
                 ,'content' => "/* Minify: at least one missing file. See " . Minify::URL_DEBUG . " */\n"
-                ,'minifier' => ''
+                ,'minifier' => 'Minify::nullMinifier'
             )));
         }
 

--- a/lib/Minify/Source.php
+++ b/lib/Minify/Source.php
@@ -104,7 +104,7 @@ class Minify_Source implements Minify_SourceInterface {
             $this->contentType = $spec['contentType'];
         }
         if (isset($spec['minifier'])) {
-            $this->minifier = $spec['minifier'];
+            $this->setMinifier($spec['minifier']);
         }
         if (isset($spec['minifyOptions'])) {
             $this->minifyOptions = $spec['minifyOptions'];
@@ -130,8 +130,15 @@ class Minify_Source implements Minify_SourceInterface {
     /**
      * {@inheritdoc}
      */
-    public function setMinifier($minifier)
+    public function setMinifier($minifier = null)
     {
+        if ($minifier === '') {
+            error_log(__METHOD__ . " cannot accept empty string. Use 'Minify::nullMinifier' or 'trim'.");
+            $minifier = 'Minify::nullMinifier';
+        }
+        if ($minifier !== null && !is_callable($minifier, true)) {
+            throw new \InvalidArgumentException('minifier must be null or a valid callable');
+        }
         $this->minifier = $minifier;
     }
 

--- a/lib/Minify/Source/Factory.php
+++ b/lib/Minify/Source/Factory.php
@@ -173,7 +173,7 @@ class Minify_Source_Factory {
                 $spec['minifyOptions']['compress'] = false;
                 // we still want URI rewriting to work for CSS
             } else {
-                $spec['minifier'] = '';
+                $spec['minifier'] = 'Minify::nullMinifier';
             }
         }
 

--- a/lib/Minify/SourceInterface.php
+++ b/lib/Minify/SourceInterface.php
@@ -27,7 +27,7 @@ interface Minify_SourceInterface {
      * @param callable $minifier
      * @return void
      */
-    public function setMinifier($minifier);
+    public function setMinifier($minifier = null);
 
     /**
      * Get options for the minifier

--- a/min_extras/cli/minify.php
+++ b/min_extras/cli/minify.php
@@ -55,7 +55,7 @@ if ($paths) {
             $sources[] = new Minify_Source(array(
                 'id' => $path,
                 'content' => "/*** $path not found ***/\n",
-                'minifier' => '',
+                'minifier' => 'Minify::nullMinifier',
             ));
         }
     }

--- a/min_extras/cli/rewrite-uris.php
+++ b/min_extras/cli/rewrite-uris.php
@@ -45,7 +45,7 @@ foreach ($paths as $path) {
         $sources[] = new Minify_Source(array(
             'id' => $path,
             'content' => "/*** $path not found ***/\n",
-            'minifier' => '',
+            'minifier' => 'Minify::nullMinifier',
         ));
     }
 }


### PR DESCRIPTION
2.2 used empty string as a magical value meaning do not minify, but in the refactoring `Minify::combineMinify` forgot to interpret this value that way and instead inherited the default compressor for the type.

This eliminates `""` as a magical value, but for BC rewrites it to `Minify::nullMinifier` in the sources.

Fixes #499