### PR TITLE
Prevent false mod_rewrite error

### DIFF
--- a/min/builder/_index.js
+++ b/min/builder/_index.js
@@ -12,7 +12,7 @@ var MUB = {
         $.ajax({
             url : '../f=' + testUri + '&' + (new Date()).getTime(),
             success : function (data) {
-                if (data === '1') {
+                if (data === '1' || data === '1;') {
                     MUB._minRoot = '/min/';
                     $('span.minRoot').html('/min/');
                 } else


### PR DESCRIPTION
If Google's Closure Compiler API is enabled, rewriteTest.js is served as
`1;` instead of `1`. Therefore the

> **Note:** Your webserver does not seem
> to support mod_rewrite (used in /min/.htaccess). Your Minify URIs will
> contain "?", which [may reduce the benefit of proxy cache servers.](http://www.stevesouders.com/blog/2008/08/23/revving-filenames-dont-use-querystring/)

on the builder site is wrong. This is a simple workaround.