### PR TITLE
lessphp: use updated timestamp from cache

### DIFF
--- a/lib/Minify/LessCssSource.php
+++ b/lib/Minify/LessCssSource.php
@@ -30,13 +30,7 @@ class Minify_LessCssSource extends Minify_Source {
     public function getLastModified() {
         $cache = $this->getCache();
 
-        $lastModified = 0;
-        foreach ($cache['files'] as $mtime) {
-            $lastModified = max($lastModified, $mtime);
-
-        }
-
-        return $lastModified;
+        return $cache['updated'];
     }
 
     /**

--- a/lib/Minify/LessCssSource.php
+++ b/lib/Minify/LessCssSource.php
@@ -30,7 +30,7 @@ class Minify_LessCssSource extends Minify_Source {
     public function getLastModified() {
         $cache = $this->getCache();
 
-        return $cache['updated'];
+        return $cache['lastModified'];
     }
 
     /**
@@ -70,10 +70,27 @@ class Minify_LessCssSource extends Minify_Source {
         $cache = $less->cachedCompile($input);
 
         if (!is_array($input) || $cache['updated'] > $input['updated']) {
+            $cache['lastModified'] = $this->getMaxLastModified($cache);
             $this->cache->store($cacheId, serialize($cache));
         }
 
         return $this->parsed = $cache;
+    }
+
+    /**
+     * Calculate maximum last modified of all files,
+     * as the 'updated' timestamp in cache is not the same as file last modified timestamp:
+     * @link https://github.com/leafo/lessphp/blob/v0.4.0/lessc.inc.php#L1904
+     * @return int
+     */
+    private function getMaxLastModified($cache)
+    {
+        $lastModified = 0;
+        foreach ($cache['files'] as $mtime) {
+            $lastModified = max($lastModified, $mtime);
+        }
+
+        return $lastModified;
     }
 
     /**
@@ -86,7 +103,7 @@ class Minify_LessCssSource extends Minify_Source {
     private function getCacheId($prefix = 'minify') {
         $md5 = md5($this->filepath);
 
-        return "{$prefix}_less_{$md5}";
+        return "{$prefix}_less2_{$md5}";
     }
 
     /**


### PR DESCRIPTION
when developing scssphp Source in #549
i found code that could be optimized in lessphp Source

no need to calculate the timestamp ourselves each time the calculated value already present in cache object