### PR TITLE
Composer compatibility - check if library is inside the vendor dir

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -4,7 +4,12 @@
  */
 
 call_user_func(function () {
-    $file = __DIR__ . '/vendor/autoload.php';
+	$vendorDir = __DIR__ . '/vendor';
+	if(file_exists(__DIR__ . '/../../../vendor')){
+		//Used as a composer library
+		$vendorDir = __DIR__ . '/../../../vendor';
+	}
+	$file = $vendorDir . '/autoload.php';
     if (!is_file($file)) {
         echo 'You must set up the project dependencies, run the following commands:'.PHP_EOL.
             'curl -sS https://getcomposer.org/installer | php'.PHP_EOL.


### PR DESCRIPTION
If this library is installed as a composer package, I'm getting the error, that I don't use composer.
My patch can fix this, and can include autoload file in this case as well