### PR TITLE
Cast value as int for PHP 7.1

### DIFF
--- a/min/lib/CSSmin.php
+++ b/min/lib/CSSmin.php
@@ -766,9 +766,9 @@ class CSSmin
     {
         if (is_string($size)) {
             switch (substr($size, -1)) {
-                case 'M': case 'm': return $size * 1048576;
-                case 'K': case 'k': return $size * 1024;
-                case 'G': case 'g': return $size * 1073741824;
+                case 'M': case 'm': return (int) $size * 1048576;
+                case 'K': case 'k': return (int) $size * 1024;
+                case 'G': case 'g': return (int) $size * 1073741824;
             }
         }
 


### PR DESCRIPTION
Running minify on a server with PHP 7.1 throws the following error: `A non well formed numeric value encountered`. Casting `$size` as an integer will remove the letters, and allow the calculation to be done properly. 

I'm aware of the version 3.x.x, but I hope the branch 2.x is still opened for bug fixes. :wink: 