### PR TITLE
Fix issue where minify() would corrupt some characters such as &nbsp; in some environments

### DIFF
--- a/lib/Minify/HTML.php
+++ b/lib/Minify/HTML.php
@@ -135,7 +135,7 @@ class Minify_HTML
             .'|canvas|caption|center|col(?:group)?|dd|dir|div|dl|dt|fieldset|figcaption|figure|footer|form'
             .'|frame(?:set)?|h[1-6]|head|header|hgroup|hr|html|legend|li|link|main|map|menu|meta|nav'
             .'|ol|opt(?:group|ion)|output|p|param|section|t(?:able|body|head|d|h||r|foot|itle)'
-            .'|ul|video)\\b[^>]*>)/i', '$1', $this->_html);
+            .'|ul|video)\\b[^>]*>)/iu', '$1', $this->_html);
 
         // remove ws outside of all elements
         $this->_html = preg_replace(

--- a/lib/Minify/HTML.php
+++ b/lib/Minify/HTML.php
@@ -99,36 +99,36 @@ class Minify_HTML
 
         // replace SCRIPTs (and minify) with placeholders
         $this->_html = preg_replace_callback(
-            '/(\\s*)<script(\\b[^>]*?>)([\\s\\S]*?)<\\/script>(\\s*)/i'
+            '/(\\s*)<script(\\b[^>]*?>)([\\s\\S]*?)<\\/script>(\\s*)/iu'
             ,array($this, '_removeScriptCB')
             ,$this->_html);
 
         // replace STYLEs (and minify) with placeholders
         $this->_html = preg_replace_callback(
-            '/\\s*<style(\\b[^>]*>)([\\s\\S]*?)<\\/style>\\s*/i'
+            '/\\s*<style(\\b[^>]*>)([\\s\\S]*?)<\\/style>\\s*/iu'
             ,array($this, '_removeStyleCB')
             ,$this->_html);
 
         // remove HTML comments (not containing IE conditional comments).
         $this->_html = preg_replace_callback(
-            '/<!--([\\s\\S]*?)-->/'
+            '/<!--([\\s\\S]*?)-->/u'
             ,array($this, '_commentCB')
             ,$this->_html);
 
         // replace PREs with placeholders
-        $this->_html = preg_replace_callback('/\\s*<pre(\\b[^>]*?>[\\s\\S]*?<\\/pre>)\\s*/i'
+        $this->_html = preg_replace_callback('/\\s*<pre(\\b[^>]*?>[\\s\\S]*?<\\/pre>)\\s*/iu'
             ,array($this, '_removePreCB')
             ,$this->_html);
 
         // replace TEXTAREAs with placeholders
         $this->_html = preg_replace_callback(
-            '/\\s*<textarea(\\b[^>]*?>[\\s\\S]*?<\\/textarea>)\\s*/i'
+            '/\\s*<textarea(\\b[^>]*?>[\\s\\S]*?<\\/textarea>)\\s*/iu'
             ,array($this, '_removeTextareaCB')
             ,$this->_html);
 
         // trim each line.
         // @todo take into account attribute values that span multiple lines.
-        $this->_html = preg_replace('/^\\s+|\\s+$/m', '', $this->_html);
+        $this->_html = preg_replace('/^\\s+|\\s+$/mu', '', $this->_html);
 
         // remove ws around block/undisplayed elements
         $this->_html = preg_replace('/\\s+(<\\/?(?:area|article|aside|base(?:font)?|blockquote|body'
@@ -139,12 +139,12 @@ class Minify_HTML
 
         // remove ws outside of all elements
         $this->_html = preg_replace(
-            '/>(\\s(?:\\s*))?([^<]+)(\\s(?:\s*))?</'
+            '/>(\\s(?:\\s*))?([^<]+)(\\s(?:\s*))?</u'
             ,'>$1$2$3<'
             ,$this->_html);
 
         // use newlines before 1st attribute in open tags (to limit line lengths)
-        $this->_html = preg_replace('/(<[a-z\\-]+)\\s+([^>]+>)/i', "$1\n$2", $this->_html);
+        $this->_html = preg_replace('/(<[a-z\\-]+)\\s+([^>]+>)/iu', "$1\n$2", $this->_html);
 
         // fill placeholders
         $this->_html = str_replace(
@@ -198,7 +198,7 @@ class Minify_HTML
         $openStyle = "<style{$m[1]}";
         $css = $m[2];
         // remove HTML comments
-        $css = preg_replace('/(?:^\\s*<!--|-->\\s*$)/', '', $css);
+        $css = preg_replace('/(?:^\\s*<!--|-->\\s*$)/u', '', $css);
 
         // remove CDATA section markers
         $css = $this->_removeCdata($css);
@@ -226,7 +226,7 @@ class Minify_HTML
 
         // remove HTML comments (and ending "//" if present)
         if ($this->_jsCleanComments) {
-            $js = preg_replace('/(?:^\\s*<!--\\s*|\\s*(?:\\/\\/)?\\s*-->\\s*$)/', '', $js);
+            $js = preg_replace('/(?:^\\s*<!--\\s*|\\s*(?:\\/\\/)?\\s*-->\\s*$)/u', '', $js);
         }
 
         // remove CDATA section markers
@@ -253,6 +253,6 @@ class Minify_HTML
 
     protected function _needsCdata($str)
     {
-        return ($this->_isXhtml && preg_match('/(?:[<&]|\\-\\-|\\]\\]>)/', $str));
+        return ($this->_isXhtml && preg_match('/(?:[<&]|\\-\\-|\\]\\]>)/u', $str));
     }
 }


### PR DESCRIPTION
Adding the `u` flag there fixes an issue in my environment (MAMP 4.1.1 with PHP 7.1.5) where `minify()` would corrupt the `&nbsp;` character (it would get replaced by the replacement character).