### PR TITLE
replace leafo/lessphp with marcusschwarz/lesserphp

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,15 +33,15 @@
 	},
 	"require-dev": {
 		"firephp/firephp-core": "~0.4.0",
-		"leafo/lessphp": "~0.4.0",
 		"leafo/scssphp": "~0.6.6",
+		"marcusschwarz/lesserphp": "~0.5.1",
 		"meenie/javascript-packer": "~1.1",
 		"phpunit/phpunit": "4.8.*",
 		"tedivm/jshrink": "~1.1.0"
 	},
 	"suggest": {
 		"firephp/firephp-core": "Use FirePHP for Log messages",
-		"leafo/lessphp": "LESS support",
+		"marcusschwarz/lesserphp": "LESS support",
 		"meenie/javascript-packer": "Keep track of the Packer PHP port using Composer"
 	},
 	"scripts": {


### PR DESCRIPTION
This is a better maintained fork of lessphp. It seems to be fully
compatible, so this is more or less a drop in replacement.

Dokuwiki switched to this fork:
https://github.com/splitbrain/dokuwiki/pull/1969