### PR TITLE
Fix closure-compiler's error "redirection limit reached"

### DIFF
--- a/lib/Minify/JS/ClosureCompiler.php
+++ b/lib/Minify/JS/ClosureCompiler.php
@@ -54,7 +54,7 @@ class Minify_JS_ClosureCompiler
     /**
      * @var string $url URL of compiler server. defaults to Google's
      */
-    protected $serviceUrl = 'http://closure-compiler.appspot.com/compile';
+    protected $serviceUrl = 'https://closure-compiler.appspot.com/compile';
 
     /**
      * @var int $maxBytes The maximum JS size that can be sent to the compiler server in bytes
@@ -174,6 +174,9 @@ class Minify_JS_ClosureCompiler
             $contents = file_get_contents($this->serviceUrl, false, stream_context_create(array(
                 'http' => array(
                     'method' => 'POST',
+                    'compilation_level' => 'SIMPLE',
+                    'output_format' => 'text',
+                    'output_info' => 'compiled_code',
                     'header' => "Content-type: application/x-www-form-urlencoded\r\nConnection: close\r\n",
                     'content' => $postBody,
                     'max_redirects' => 0,


### PR DESCRIPTION
Since a few days, the js minification was complaining about a redirection limit in the closure-compiler call. This was generating an error each time I have tried to use this tool.

After a bit of investigation I have found out that it was missing some parameters that are now mandatory. Plus, it now works in https only.