### PR TITLE
travis: test php 5.3..7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,25 @@
 language: php
 sudo: false
+dist: trusty
 
-php:
-  - 7.0
-  - 5.6
-  - 5.5
-  - 5.4
-  - hhvm
+jobs:
+  fast_finish: true
+  allow_failures:
+    - php: "hhvm"
+  include:
+    - php: "5.3"
+      dist: precise
+    - php: "5.4"
+    - php: "5.5"
+    - php: "5.6"
+    - php: "7.0"
+    - php: "7.1"
+    - php: "7.2"
+    - php: "nightly"
+    - php: "hhvm"
 
 env:
   - CLOSURE_VERSION: 20161024
-
-matrix:
-  allow_failures:
-    - php: hhvm
-    - php: 7.0
 
 services:
   - memcached

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 	},
 	"require-dev": {
 		"firephp/firephp-core": "~0.4.0",
-		"leafo/scssphp": "~0.6.6",
+		"leafo/scssphp": "^0.3 || ^0.6 || ^0.7",
 		"marcusschwarz/lesserphp": "~0.5.1",
 		"meenie/javascript-packer": "~1.1",
 		"phpunit/phpunit": "^4.8.36",

--- a/tests/HTTPEncoderTest.php
+++ b/tests/HTTPEncoderTest.php
@@ -7,7 +7,7 @@ use HTTP_Encoder;
 class HTTPEncoderTest extends TestCase
 {
     /**
-     * @dataProvider testToIe6Data
+     * @dataProvider ToIe6DataProvider
      * @preserveGlobals
      */
     public function testToIe6($ua, $ae, $exp, $desc)
@@ -20,7 +20,7 @@ class HTTPEncoderTest extends TestCase
         $this->assertSame($exp, $ret, $desc);
     }
 
-    public function testToIe6Data()
+    public function ToIe6DataProvider()
     {
         return array(
             array(
@@ -69,7 +69,7 @@ class HTTPEncoderTest extends TestCase
     }
 
     /**
-     * @dataProvider testEncodeNonIeData
+     * @dataProvider EncodeNonIeDataProvider
      */
     public function testEncodeNonIe($ua, $ae, $exp, $desc)
     {
@@ -81,7 +81,7 @@ class HTTPEncoderTest extends TestCase
         $this->assertSame($exp, $ret, $desc);
     }
 
-    public function testEncodeNonIeData()
+    public function EncodeNonIeDataProvider()
     {
         return array(
             array(

--- a/tests/JSMinTest.php
+++ b/tests/JSMinTest.php
@@ -57,7 +57,8 @@ class JSMinTest extends TestCase
      * @param string $label
      * @param string $expClass
      * @param string $expMessage
-     * @dataProvider testJSMinExceptionData
+     *
+     * @dataProvider JSMinExceptionDataProvider
      */
     public function testJSMinException($js, $label, $expClass, $expMessage)
     {
@@ -71,7 +72,7 @@ class JSMinTest extends TestCase
         $this->assertTrue($eClass === $expClass && $eMsg === $expMessage, 'Throw on ' . $label);
     }
 
-    public function testJSMinExceptionData()
+    public function JSMinExceptionDataProvider()
     {
         // $js, $label, $expClass, $expMessage
         return array(

--- a/tests/ScssSourceTest.php
+++ b/tests/ScssSourceTest.php
@@ -8,10 +8,6 @@ class ScssSourceTest extends TestCase
 {
     public function setUp()
     {
-        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
-            $this->markTestSkipped('scssphp is not compatible with this PHP version.');
-        }
-
         $this->realDocRoot = $_SERVER['DOCUMENT_ROOT'];
         $_SERVER['DOCUMENT_ROOT'] = self::$document_root;
     }


### PR DESCRIPTION
this restores testing with php 5.3 and adds php 7.1-7.3

also leafo/scssphp 0.3 is allowed again (commit ddf3a4e57f via #562)

copied from https://github.com/eventum/rpc/pull/2
  