### PR TITLE
Set "Vary: Accept-Encoding" header only if encoding is set and not empty

### DIFF
--- a/lib/HTTP/ConditionalGet.php
+++ b/lib/HTTP/ConditionalGet.php
@@ -128,8 +128,8 @@ class HTTP_ConditionalGet
         $etagAppend = '';
         if (isset($spec['encoding'])) {
             $this->_stripEtag = true;
-            $this->_headers['Vary'] = 'Accept-Encoding';
             if ('' !== $spec['encoding']) {
+                $this->_headers['Vary'] = 'Accept-Encoding';
                 if (0 === strpos($spec['encoding'], 'x-')) {
                     $spec['encoding'] = substr($spec['encoding'], 2);
                 }


### PR DESCRIPTION
I noticed that in the options provided for the constructor of `HTTP_ConditionalGet` the `encoding` option could never be `null` causing the "Vary: Accept-Encoding" header to be always sent. By this change it will only be set if the `encoding` has a value different than the empty string.