### PR TITLE
Do not pass undefined variables into compact() for PHP 7.3

### DIFF
--- a/lib/Minify/App.php
+++ b/lib/Minify/App.php
@@ -80,6 +80,11 @@ class App extends Container
             };
             $varNames = array_map($prefixer, $propNames);
 
+            $varDefinedChecker = function ($name) {
+                return array_key_exists($name, get_defined_vars());
+            };
+            $varNames = array_filter($varNames, $varDefinedChecker);
+
             $vars = compact($varNames);
 
             foreach ($varNames as $varName) {


### PR DESCRIPTION
In PHP7.3, compact prints out an error if a variable is not defined.
On Chrome, this shows up as ERR_CONTENT_DECODING_FAILED