### PR TITLE
Bugfix for option sanitizer

### DIFF
--- a/lib/Minify/App.php
+++ b/lib/Minify/App.php
@@ -80,10 +80,12 @@ class App extends Container
             };
             $varNames = array_map($prefixer, $propNames);
 
-            $varDefinedChecker = function ($name) {
-                return array_key_exists($name, get_defined_vars());
-            };
-            $varNames = array_filter($varNames, $varDefinedChecker);
+            $varDefined = get_defined_vars();
+
+            $varNames = array_filter($varNames, function($name) use($varDefined)
+            {
+                return array_key_exists($name, $varDefined);
+            });
 
             $vars = compact($varNames);
 


### PR DESCRIPTION
Fixes: https://github.com/mrclay/minify/issues/654

I ran into the exact same problem when updating to 3.0.5. The problematic commit is:

https://github.com/mrclay/minify/commit/f50353a9521dca7503be4127c49022ed14b4d594#diff-0a33c0dcf39fa4df82a80b0cb6f0fe03

This newly commited code cleanr the config, so the code will run into a permission due to a missing allowDirs configuration and debugging won't be enabled (hence no error message in FirePHP and the likes).

I'm not exactly sure why the config variables are sanitized, but if this has to work the callable for array_filter needs the defined variables passed into the closure like this:

```
$varDefined = get_defined_vars();

$varNames = array_filter($varNames, function($name) use($varDefined)
{
    return array_key_exists($name, $varDefined);
});
```