### PR TITLE
Upgrade mrclay/props-dic

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 		"intervention/httpauth": "~2.0",
 		"monolog/monolog": "~1.1|~2.0",
 		"mrclay/jsmin-php": "~2",
-		"mrclay/props-dic": "^2.2",
+		"mrclay/props-dic": "^3.0",
 		"php": "^5.3.0 || ^7.0",
 		"tubalmartin/cssmin": "~4",
 		"marcusschwarz/lesserphp": "~0.5.1"

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
 		"intervention/httpauth": "~2.0",
 		"monolog/monolog": "~1.1|~2.0",
 		"mrclay/jsmin-php": "~2",
-		"mrclay/props-dic": "^3.0",
+		"mrclay/props-dic": "^2.2|^3.0",
 		"php": "^5.3.0 || ^7.0",
 		"tubalmartin/cssmin": "~4",
 		"marcusschwarz/lesserphp": "~0.5.1"


### PR DESCRIPTION
As per https://github.com/mrclay/Props/pull/7, the `container-interop/container-interop` package is abandoned, and `mrclay/props-dic` 3.0 has been tagged to fix it. (Thanks!)

Since there are no functional changes, minify can probably be tagged as 3.0.7 once this is merged.