### PR TITLE
Force lesserphp to v0.5.2 because v0.5.3 changed namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 		"php": "^5.3.0 || ^7.0",
 		"ext-pcre": "*",
 		"intervention/httpauth": "~2.0",
-		"marcusschwarz/lesserphp": "~0.5.1",
+		"marcusschwarz/lesserphp": "0.5.2",
 		"monolog/monolog": "~1.1|~2.0",
 		"mrclay/jsmin-php": "~2",
 		"mrclay/props-dic": "^2.2|^3.0",


### PR DESCRIPTION
Force lesserphp to specific version with old namespacing:
- https://github.com/MarcusSchwarz/lesserphp/issues/17