### PR TITLE
Function get_magic_quotes_gpc() is now deprecated in PHP 7.4

### DIFF
--- a/lib/HTTP/ConditionalGet.php
+++ b/lib/HTTP/ConditionalGet.php
@@ -317,9 +317,7 @@ class HTTP_ConditionalGet
         if (!isset($_SERVER['HTTP_IF_NONE_MATCH'])) {
             return false;
         }
-        $clientEtagList = get_magic_quotes_gpc()
-            ? stripslashes($_SERVER['HTTP_IF_NONE_MATCH'])
-            : $_SERVER['HTTP_IF_NONE_MATCH'];
+        $clientEtagList = $_SERVER['HTTP_IF_NONE_MATCH'];
         $clientEtags = explode(',', $clientEtagList);
 
         $compareTo = $this->normalizeEtag($this->_etag);


### PR DESCRIPTION
- removed deprecated function that since PHP 5.4.0 returns FALSE always, and since PHP 7.4 is deprecated.

ref: https://www.php.net/manual/en/function.get-magic-quotes-gpc.php

Fixes #661