### PR TITLE
Exclude SSI Comments

### DIFF
--- a/lib/Minify/HTML.php
+++ b/lib/Minify/HTML.php
@@ -164,7 +164,7 @@ class Minify_HTML
 
     protected function _commentCB($m)
     {
-        return (0 === strpos($m[1], '[') || false !== strpos($m[1], '<![') || (0 === strpos($m[1], '#'))
+        return (0 === strpos($m[1], '[') || false !== strpos($m[1], '<![') || 0 === strpos($m[1], '#'))
             ? $m[0]
             : '';
     }

--- a/lib/Minify/HTML.php
+++ b/lib/Minify/HTML.php
@@ -164,7 +164,7 @@ class Minify_HTML
 
     protected function _commentCB($m)
     {
-        return (0 === strpos($m[1], '[') || false !== strpos($m[1], '<!['))
+        return (0 === strpos($m[1], '[') || false !== strpos($m[1], '<![') || (0 === strpos($m[1], '#'))
             ? $m[0]
             : '';
     }

--- a/tests/_test_files/html/before.html
+++ b/tests/_test_files/html/before.html
@@ -9,6 +9,11 @@
 	<meta name="description" content="A demonstration of what can be accomplished visually through CSS-based design." />
 	<meta name="robots" content="all" />
 	<title>css Zen Garden: The Beauty in CSS Design</title>
+	<!--# if expr="$HTTP_COOKIE=/minify\=1/" -->
+	<meta name="generator" content="minify-cookie" />
+	<!--# else -->
+	<meta name="generator" content="minify-no-cookie" />
+	<!--# endif -->
 
 	<!-- to correct the unsightly Flash of Unstyled Content. http://www.bluerobot.com/web/css/fouc.asp -->
 	<script type="text/javascript"><!--
@@ -63,11 +68,11 @@ css hack {
     display:none;
 }
 	</style>
-	<link 
+	<link
 		rel="Shortcut Icon"
 		type="image/x-icon"
 		href="http://www.csszengarden.com/favicon.ico" />
-	<link 
+	<link
 		rel="alternate"
 		type="application/rss+xml"
 		title="RSS"
@@ -78,7 +83,7 @@ css hack {
 <div id="container">
 		<div id="pageHeader">
 			<h1><span>css Zen Garden</span></h1>
-			<h2><span>The Beauty of <acronym title="Cascading Style Sheets">CSS</acronym>  
+			<h2><span>The Beauty of <acronym title="Cascading Style Sheets">CSS</acronym>
 Design</span></h2>
 		</div>
 		<pre>

--- a/tests/_test_files/html/before.min.html
+++ b/tests/_test_files/html/before.min.html
@@ -4,7 +4,12 @@ http-equiv="content-type" content="text/html; charset=iso-8859-1" /><meta
 name="author" content="Dave Shea" /><meta
 name="keywords" content="design, css, cascading, style, sheets, xhtml, graphic design, w3c, web standards, visual, display" /><meta
 name="description" content="A demonstration of what can be accomplished visually through CSS-based design." /><meta
-name="robots" content="all" /><title>css Zen Garden: The Beauty in CSS Design</title> <script type="text/javascript">var is={ie:navigator.appName=='Microsoft Internet Explorer',java:navigator.javaEnabled(),ns:navigator.appName=='Netscape',ua:navigator.userAgent.toLowerCase(),version:parseFloat(navigator.appVersion.substr(21))||parseFloat(navigator.appVersion),win:navigator.platform=='Win32'}
+name="robots" content="all" /><title>css Zen Garden: The Beauty in CSS Design</title>
+<!--# if expr="$HTTP_COOKIE=/minify\=1/" --><meta
+name="generator" content="minify-cookie" />
+<!--# else --><meta
+name="generator" content="minify-no-cookie" />
+<!--# endif --> <script type="text/javascript">var is={ie:navigator.appName=='Microsoft Internet Explorer',java:navigator.javaEnabled(),ns:navigator.appName=='Netscape',ua:navigator.userAgent.toLowerCase(),version:parseFloat(navigator.appVersion.substr(21))||parseFloat(navigator.appVersion),win:navigator.platform=='Win32'}
 is.mac=is.ua.indexOf('mac')>=0;if(is.ua.indexOf('opera')>=0){is.ie=is.ns=false;is.opera=true;}
 if(is.ua.indexOf('gecko')>=0){is.ie=is.ns=false;is.gecko=true;}</script> <script type="text/javascript">/*<![CDATA[*/var i=0;while(++i<10)
 {}/*]]>*/</script> <script type="text/javascript">i=1;</script> <script type="text/javascript">/*<![CDATA[*/(i<1);/*]]>*/</script> <!--[if IE 6]><style type="text/css">/*<![CDATA[*//*! copyright: you'll need CDATA for this < & */

--- a/tests/_test_files/html/before2.html
+++ b/tests/_test_files/html/before2.html
@@ -9,6 +9,11 @@
 	<meta name="description" content="A demonstration of what can be accomplished visually through CSS-based design.">
 	<meta name="robots" content="all">
 	<title>css Zen Garden: The Beauty in CSS Design</title>
+	<!--# if expr="$HTTP_COOKIE=/minify\=1/" -->
+	<meta name="generator" content="minify-cookie" />
+	<!--# else -->
+	<meta name="generator" content="minify-no-cookie" />
+	<!--# endif -->
 
 	<!-- to correct the unsightly Flash of Unstyled Content. http://www.bluerobot.com/web/css/fouc.asp -->
 	<script type="text/javascript"><!--
@@ -61,11 +66,11 @@ css hack {
     display:none;
 }
 	</style>
-	<link 
+	<link
 		rel="Shortcut Icon"
 		type="image/x-icon"
 		href="http://www.csszengarden.com/favicon.ico">
-	<link 
+	<link
 		rel="alternate"
 		type="application/rss+xml"
 		title="RSS"
@@ -76,7 +81,7 @@ css hack {
 <div id="container">
 		<div id="pageHeader">
 			<h1><span>css Zen Garden</span></h1>
-			<h2><span>The Beauty of <acronym title="Cascading Style Sheets">CSS</acronym>  
+			<h2><span>The Beauty of <acronym title="Cascading Style Sheets">CSS</acronym>
 Design</span></h2>
 		</div>
 		<pre>

--- a/tests/_test_files/html/before2.min.html
+++ b/tests/_test_files/html/before2.min.html
@@ -4,7 +4,12 @@ http-equiv="content-type" content="text/html; charset=iso-8859-1"><meta
 name="author" content="Dave Shea"><meta
 name="keywords" content="design, css, cascading, style, sheets, xhtml, graphic design, w3c, web standards, visual, display"><meta
 name="description" content="A demonstration of what can be accomplished visually through CSS-based design."><meta
-name="robots" content="all"><title>css Zen Garden: The Beauty in CSS Design</title> <script type="text/javascript">var is={ie:navigator.appName=='Microsoft Internet Explorer',java:navigator.javaEnabled(),ns:navigator.appName=='Netscape',ua:navigator.userAgent.toLowerCase(),version:parseFloat(navigator.appVersion.substr(21))||parseFloat(navigator.appVersion),win:navigator.platform=='Win32'}
+name="robots" content="all"><title>css Zen Garden: The Beauty in CSS Design</title>
+<!--# if expr="$HTTP_COOKIE=/minify\=1/" --><meta
+name="generator" content="minify-cookie" />
+<!--# else --><meta
+name="generator" content="minify-no-cookie" />
+<!--# endif --> <script type="text/javascript">var is={ie:navigator.appName=='Microsoft Internet Explorer',java:navigator.javaEnabled(),ns:navigator.appName=='Netscape',ua:navigator.userAgent.toLowerCase(),version:parseFloat(navigator.appVersion.substr(21))||parseFloat(navigator.appVersion),win:navigator.platform=='Win32'}
 is.mac=is.ua.indexOf('mac')>=0;if(is.ua.indexOf('opera')>=0){is.ie=is.ns=false;is.opera=true;}
 if(is.ua.indexOf('gecko')>=0){is.ie=is.ns=false;is.gecko=true;}</script> <script type="text/javascript">var i=0;while(++i<10)
 {}</script> <script type="text/javascript">i=1;</script> <script type="text/javascript">(i<1);</script> <!--[if IE 6]><style type="text/css">/*! copyright: you'll need CDATA for this < & */


### PR DESCRIPTION
Exclude Nginx & Apache Server Side Include (SSI) comments from being stripped via minification, the same way IE directives are not stripped.

Both Nginx & Apache SSI directives begin with:
```
<!--#
```
So we can just look for the # and don’t strip the comment in that case.

Nginx SSI: http://nginx.org/en/docs/http/ngx_http_ssi_module.html

Apache SSI: https://httpd.apache.org/docs/2.4/howto/ssi.html

Resolves: https://github.com/mrclay/minify/issues/671