### PR TITLE
Disable less tests on php 7.4+

### DIFF
--- a/tests/LessSourceTest.php
+++ b/tests/LessSourceTest.php
@@ -4,6 +4,9 @@ namespace Minify\Test;
 
 use Minify_HTML_Helper;
 
+/**
+ * @requires php < 7.3
+ */
 class LessSourceTest extends TestCase
 {
     public function setUp()


### PR DESCRIPTION
marcusschwarz/lesserphp needs updating

```
1) Minify\Test\LessSourceTest::testLessTimestamp
Array and string offset access syntax with curly braces is deprecated
/home/travis/build/mrclay/minify/vendor/marcusschwarz/lesserphp/lessc.inc.php:761
/home/travis/build/mrclay/minify/lib/Minify/LessCssSource.php:122
/home/travis/build/mrclay/minify/lib/Minify/LessCssSource.php:73
/home/travis/build/mrclay/minify/lib/Minify/LessCssSource.php:34
/home/travis/build/mrclay/minify/lib/Minify/HTML/Helper.php:155
/home/travis/build/mrclay/minify/lib/Minify/HTML/Helper.php:134
/home/travis/build/mrclay/minify/lib/Minify/HTML/Helper.php:51
/home/travis/build/mrclay/minify/tests/LessSourceTest.php:38
```
- https://travis-ci.org/github/mrclay/minify/jobs/738586375

and that is out of our control:
- https://github.com/MarcusSchwarz/lesserphp/pull/19