### PR TITLE
Fix null argument to preg_split

### DIFF
--- a/lib/Minify/CSS/Compressor.php
+++ b/lib/Minify/CSS/Compressor.php
@@ -259,7 +259,7 @@ class Minify_CSS_Compressor
     {
         // Issue 210: must not eliminate WS between words in unquoted families
         $flags = PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY;
-        $pieces = preg_split('/(\'[^\']+\'|"[^"]+")/', $m[1], null, $flags);
+        $pieces = preg_split('/(\'[^\']+\'|"[^"]+")/', $m[1], -1, $flags);
         $out = 'font-family:';
 
         while (null !== ($piece = array_shift($pieces))) {


### PR DESCRIPTION
Fix null argument to preg_split

```
Deprecated Functionality: preg_split(): Passing null to parameter #3 ($limit) of type int is deprecated
```

- https://www.php.net/manual/en/function.preg-split.php#refsect1-function.preg-split-parameters

`limit`:

> If specified, then only substrings up to limit are returned with the rest of the string being placed in the last substring. A limit of -1 or 0 means "no limit".

Refs:
- https://www.drupal.org/project/geshifilter/issues/3262325

Fixes #695