### PR TITLE
Support monolog v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 		"ext-pcre": "*",
 		"intervention/httpauth": "^2.0|^3.0",
 		"marcusschwarz/lesserphp": "^0.5.5",
-		"monolog/monolog": "~1.1|~2.0",
+		"monolog/monolog": "~1.1|~2.0|~3.0",
 		"mrclay/jsmin-php": "~2",
 		"mrclay/props-dic": "^2.2|^3.0",
 		"tubalmartin/cssmin": "~4"


### PR DESCRIPTION
This adds Monolog 3.0 as a supported dependency, as none of the features this package use are affected by the version bump.

Closes #704