### PR TITLE
Add support for php 8.4

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         php-versions:
-          ["8.1", "8.2", "8.3"]
+          ["8.1", "8.2", "8.3", "8.4"]
 
     name: PHP ${{ matrix.php-versions }} Test on ubantu-latest
     steps:

--- a/lib/Minify.php
+++ b/lib/Minify.php
@@ -85,7 +85,7 @@ class Minify
      * @param Minify_CacheInterface $cache
      * @param LoggerInterface       $logger
      */
-    public function __construct(Minify_CacheInterface $cache, LoggerInterface $logger = null)
+    public function __construct(Minify_CacheInterface $cache, ?LoggerInterface $logger = null)
     {
         $this->cache = $cache;
         $this->logger = $logger;

--- a/lib/Minify/Cache/File.php
+++ b/lib/Minify/Cache/File.php
@@ -29,7 +29,7 @@ class Minify_Cache_File implements Minify_CacheInterface
      * @param bool            $fileLocking
      * @param LoggerInterface $logger
      */
-    public function __construct($path = '', $fileLocking = false, LoggerInterface $logger = null)
+    public function __construct($path = '', $fileLocking = false, ?LoggerInterface $logger = null)
     {
         if (! $path) {
             $path = sys_get_temp_dir();

--- a/lib/Minify/Controller/Base.php
+++ b/lib/Minify/Controller/Base.php
@@ -38,7 +38,7 @@ abstract class Minify_Controller_Base implements Minify_ControllerInterface
      * @param Minify_Source_Factory $sourceFactory
      * @param LoggerInterface       $logger
      */
-    public function __construct(Minify_Env $env, Minify_Source_Factory $sourceFactory, LoggerInterface $logger = null)
+    public function __construct(Minify_Env $env, Minify_Source_Factory $sourceFactory, ?LoggerInterface $logger = null)
     {
         $this->env = $env;
         $this->sourceFactory = $sourceFactory;

--- a/lib/Minify/HTML/Helper.php
+++ b/lib/Minify/HTML/Helper.php
@@ -163,7 +163,7 @@ class Minify_HTML_Helper
      * @return \Minify\App
      * @internal
      */
-    public static function app(\Minify\App $app = null)
+    public static function app(?\Minify\App $app = null)
     {
         static $cached;
         if ($app) {

--- a/lib/Minify/Source/Factory.php
+++ b/lib/Minify/Source/Factory.php
@@ -44,7 +44,7 @@ class Minify_Source_Factory
      * @param Minify_CacheInterface $cache Optional cache for handling .less files.
      *
      */
-    public function __construct(Minify_Env $env, array $options = array(), Minify_CacheInterface $cache = null)
+    public function __construct(Minify_Env $env, array $options = array(), ?Minify_CacheInterface $cache = null)
     {
         $this->env = $env;
         $this->options = array_merge(array(

--- a/lib/MrClay/Cli.php
+++ b/lib/MrClay/Cli.php
@@ -108,7 +108,7 @@ class Cli
      * @return Arg
      * @throws InvalidArgumentException
      */
-    public function addArgument($letter, $required, Arg $arg = null)
+    public function addArgument($letter, $required, ?Arg $arg = null)
     {
         if (! preg_match('/^[a-zA-Z]$/', $letter)) {
             throw new InvalidArgumentException('$letter must be in [a-zA-Z]');


### PR DESCRIPTION
This pr adds php 8.4 to the gh-actions and fixes the deprecation notices, caused by implicitly nullable parameters.