### PR TITLE
Fix: Add scssphp 2.x compatibility while maintaining backward compatibility

### DIFF
--- a/.semver
+++ b/.semver
@@ -1,6 +1,6 @@
 ---
 :major: 4
 :minor: 0
-:patch: 1
+:patch: 2
 :special: ''
 :metadata: ''

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [4.0.2] - 2026-01-22
+
+- Add scssphp 2.x compatibility while maintaining backward compatibility, [#715]
+- Use `CompilationResult::getIncludedFiles()` for scssphp 2.x, fall back to `Compiler::getParsedFiles()` for scssphp 1.x
+
+[4.0.2]: https://github.com/mrclay/minify/compare/4.0.1...4.0.2
+[#715]: https://github.com/mrclay/minify/issues/715
+
 ## [4.0.1] - 2025-02-03
 
 - Recommend against use, [#711]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [4.0.2] - 2026-01-22
+## [4.0.2] - 2026-02-14
 
 - Add scssphp 2.x compatibility while maintaining backward compatibility, [#715]
 - Use `CompilationResult::getIncludedFiles()` for scssphp 2.x, fall back to `Compiler::getParsedFiles()` for scssphp 1.x

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
 		"firephp/firephp-core": "~0.4.0",
 		"meenie/javascript-packer": "~1.1",
 		"phpunit/phpunit": "^8",
-		"scssphp/scssphp": "^1.12",
+		"scssphp/scssphp": "^1.12|^2.0",
 		"tedivm/jshrink": "~1.1.0"
 	},
 	"suggest": {


### PR DESCRIPTION
## Summary

This PR adds compatibility with **scssphp 2.x** while maintaining backward compatibility with scssphp 1.x.

## Problem

The current implementation uses `Compiler::getParsedFiles()` which was **removed in scssphp 2.0**. This causes a fatal error when using mrclay/minify with scssphp 2.x:

```
Fatal error: Call to undefined method ScssPhp\ScssPhp\Compiler::getParsedFiles()
in vendor/mrclay/minify/lib/Minify/ScssCssSource.php
```

Since scssphp 2.x is required for **PHP 8.5 compatibility**, this fix is necessary for future PHP versions.

## Changes

- Updated `Minify_ScssCssSource::compile()` to use `CompilationResult::getIncludedFiles()` for scssphp 2.x
- Falls back to `Compiler::getParsedFiles()` for scssphp 1.x (runtime detection via `method_exists()`)
- The new scssphp 2.x API returns file paths only, so modification times are now retrieved via `filemtime()`
- Updated `composer.json` to allow `scssphp/scssphp: ^1.12|^2.0`

## Related Issues

Fixes #715